### PR TITLE
Improve usability and Readability

### DIFF
--- a/src/main/java/com/liveramp/hyperminhash/SketchCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/SketchCombiner.java
@@ -13,7 +13,8 @@ public interface SketchCombiner<T extends IntersectionSketch> extends Serializab
 
   /**
    * Return a sketch representing the union of the sets represented by the sketches in {@code
-   * sketches}.
+   * sketches}. Sketches passed will not be mutated. If only a single sketch is passed, this method
+   * will return a deep copy.
    */
   T union(T... sketches);
 

--- a/src/main/java/com/liveramp/hyperminhash/betaminhash/BetaMinHashCombiner.java
+++ b/src/main/java/com/liveramp/hyperminhash/betaminhash/BetaMinHashCombiner.java
@@ -14,6 +14,96 @@ public class BetaMinHashCombiner implements SketchCombiner<BetaMinHash> {
     return INSTANCE;
   }
 
+  @Override
+  public final BetaMinHash union(BetaMinHash... sketches) {
+    if (sketches.length == 0) {
+      throw new IllegalArgumentException("Input sketches cannot be empty.");
+    }
+
+    if (sketches.length == 1) {
+      return BetaMinHash.deepCopy(sketches[0]);
+    }
+
+    int numRegisters = sketches[0].registers.length;
+
+    BetaMinHash mergedSketch = BetaMinHash.deepCopy(sketches[0]);
+    for (int i = 0; i < numRegisters; i++) {
+      for (BetaMinHash sketch : sketches) {
+        mergedSketch.registers[i] = max(
+            mergedSketch.registers[i],
+            sketch.registers[i]
+        );
+      }
+    }
+
+    return mergedSketch;
+  }
+
+  @Override
+  public long intersectionCardinality(BetaMinHash... sketches) {
+    if (sketches.length == 0) {
+      throw new IllegalArgumentException("Input sketches cannot be empty.");
+    }
+
+    return (long) (similarity(sketches) * union(sketches).cardinality());
+  }
+
+  @Override
+  public double similarity(BetaMinHash... sketches) {
+    // Algorithm 4 in HyperMinHash paper
+    if (sketches.length == 0) {
+      throw new IllegalArgumentException("Input sketches cannot be empty.");
+    }
+
+    if (sketches.length == 1) {
+      return 1.0;
+    }
+
+    long c = 0;
+    long n = 0;
+    for (int i = 0; i < sketches[0].registers.length; i++) {
+      if (sketches[0].registers[i] != 0) {
+        boolean itemInIntersection = true;
+        for (BetaMinHash sketch : sketches) {
+          itemInIntersection =
+              itemInIntersection && sketches[0].registers[i] == sketch.registers[i];
+        }
+
+        if (itemInIntersection) {
+          c++;
+        }
+      }
+
+      for (BetaMinHash sketch : sketches) {
+        if (sketch.registers[i] != 0) {
+          n++;
+          break;
+        }
+      }
+    }
+
+    if (c == 0) {
+      return 0;
+    }
+
+    double[] cardinalities = new double[sketches.length];
+    int i = 0;
+    for (BetaMinHash sk : sketches) {
+      cardinalities[i++] = sk.cardinality();
+    }
+
+    int p = BetaMinHash.P;
+    int q = BetaMinHash.Q;
+    int r = BetaMinHash.R;
+    double numExpectedCollisions = expectedCollision(p, q, r, cardinalities);
+
+    if (c < numExpectedCollisions) {
+      return 0;
+    }
+
+    return (c - numExpectedCollisions) / (double) n;
+  }
+
   private static double expectedCollision(int p, int q, int r, double... cardinalities) {
     final int _2q = 1 << q;
     final int _2r = 1 << r;
@@ -47,95 +137,5 @@ public class BetaMinHashCombiner implements SketchCombiner<BetaMinHash> {
 
   private static short max(short a, short b) {
     return a > b ? a : b;
-  }
-
-  @Override
-  public final BetaMinHash union(BetaMinHash... sketches) {
-    if (sketches.length == 0) {
-      throw new IllegalArgumentException("Input sketches cannot be empty.");
-    }
-
-    if (sketches.length == 1) {
-      return sketches[0];
-    }
-
-    int numRegisters = sketches[0].registers.length;
-
-    BetaMinHash mergedSketch = new BetaMinHash(sketches[0]);
-    for (int i = 0; i < numRegisters; i++) {
-      for (BetaMinHash sketch : sketches) {
-        mergedSketch.registers[i] = max(
-            mergedSketch.registers[i],
-            sketch.registers[i]
-        );
-      }
-    }
-
-    return mergedSketch;
-  }
-
-  @Override
-  public long intersectionCardinality(BetaMinHash... sketches) {
-    if (sketches.length == 0) {
-      throw new IllegalArgumentException("Input sketches cannot be empty.");
-    }
-
-    return (long) (similarity(sketches) * union(sketches).cardinality());
-  }
-
-  @Override
-  public double similarity(BetaMinHash... sketches) {
-    // Algorithm 4 in HyperMinHash paper
-    if (sketches.length == 0) {
-      throw new IllegalArgumentException("Input sketches cannot be empty.");
-    }
-
-    if (sketches.length == 1) {
-      return 1.0;
-    }
-
-    long C = 0;
-    long N = 0;
-    for (int i = 0; i < sketches[0].registers.length; i++) {
-      if (sketches[0].registers[i] != 0) {
-        boolean itemInIntersection = true;
-        for (BetaMinHash sketch : sketches) {
-          itemInIntersection =
-              itemInIntersection && sketches[0].registers[i] == sketch.registers[i];
-        }
-
-        if (itemInIntersection) {
-          C++;
-        }
-      }
-
-      for (BetaMinHash sketch : sketches) {
-        if (sketch.registers[i] != 0) {
-          N++;
-          break;
-        }
-      }
-    }
-
-    if (C == 0) {
-      return 0;
-    }
-
-    double[] cardinalities = new double[sketches.length];
-    int i = 0;
-    for (BetaMinHash sk : sketches) {
-      cardinalities[i++] = sk.cardinality();
-    }
-
-    int p = BetaMinHash.P;
-    int q = BetaMinHash.Q;
-    int r = BetaMinHash.R;
-    double numExpectedCollisions = expectedCollision(p, q, r, cardinalities);
-
-    if (C < numExpectedCollisions) {
-      return 0;
-    }
-
-    return (C - numExpectedCollisions) / (double) N;
   }
 }

--- a/src/main/java/com/liveramp/hyperminhash/betaminhash/BetaMinHashWritable.java
+++ b/src/main/java/com/liveramp/hyperminhash/betaminhash/BetaMinHashWritable.java
@@ -19,16 +19,17 @@ public class BetaMinHashWritable implements Writable {
   }
 
   public BetaMinHash getSketch() {
-    return new BetaMinHash(registers);
+    return BetaMinHash.deepCopyFromRegisters(registers);
   }
 
   public BetaMinHashWritable combine(BetaMinHashWritable other) {
     BetaMinHash mergedSketch = BetaMinHashCombiner
         .getInstance()
-        .union(new BetaMinHash(registers), other.getSketch());
+        .union(BetaMinHash.wrapRegisters(registers), other.getSketch());
     return new BetaMinHashWritable(mergedSketch);
   }
 
+  @Override
   public void write(DataOutput dataOutput) throws IOException {
     for (short register : registers) {
       dataOutput.writeShort(register);

--- a/test/main/java/com/liveramp/hyperminhash/betaminhash/TestBetaMinHash.java
+++ b/test/main/java/com/liveramp/hyperminhash/betaminhash/TestBetaMinHash.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.codec.binary.Hex;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -154,6 +155,17 @@ public class TestBetaMinHash {
       intersectionSize <<= 1;
       sketchSize <<= 1;
     }
+  }
+
+  @Test
+  public void testToFromBytes() {
+    final BetaMinHash original = new BetaMinHash();
+    original.offer("test data".getBytes());
+
+    final byte[] serialized = original.getBytes();
+    final BetaMinHash deSerialized = BetaMinHash.fromBytes(serialized);
+
+    Assert.assertEquals(original, deSerialized);
   }
 
   // builds equally sized sketches which share numSharedElements items


### PR DESCRIPTION
 - Adds `fromBytes()` factory method to serve as a counterpart to `getBytes()`
 - Adds `deepCopyFromRegisters()` and `wrapRegisters()` package-private static factory methods. I think these are more readable than the constructor that takes registers as an argument, since the behavior (do we wrap the registers or copy them?) is described

@sherifnada PTAL